### PR TITLE
fix: 나의 챗봇 기록 조회되도록 구현

### DIFF
--- a/src/main/kotlin/busanVibe/busan/domain/chat/repository/ChatMongoRepository.kt
+++ b/src/main/kotlin/busanVibe/busan/domain/chat/repository/ChatMongoRepository.kt
@@ -4,11 +4,15 @@ import busanVibe.busan.domain.chat.domain.ChatMessage
 import busanVibe.busan.domain.chat.enums.MessageType
 import org.springframework.data.domain.Pageable
 import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.data.mongodb.repository.Query
 
 interface ChatMongoRepository: MongoRepository<ChatMessage, String> {
-    fun findAllByOrderByTimeDesc(pageable: Pageable): List<ChatMessage>
-    fun findByIdLessThanOrderByTimeDesc(id: String, pageable: Pageable): List<ChatMessage>
-    fun findAllByTypeOrderByTimeDesc(type: MessageType, pageable: Pageable): List<ChatMessage>
-    fun findByIdLessThanAndTypeOrderByTimeDesc(id: String, type: MessageType, pageable: Pageable): List<ChatMessage>
+
+    @Query("{ \"\$or\": [ { \"type\": { \"\$in\": ['BOT_REQUEST', 'BOT_RESPONSE'] }, \"userId\": ?0 }, { \"type\": { \"\$nin\": ['BOT_REQUEST', 'BOT_RESPONSE'] } } ] }")
+    fun findAllWithBotFilter(userId: Long, pageable: Pageable): List<ChatMessage>
+
+    @Query("{ \"\$and\": [ { \"_id\": { \"\$lt\": ?1 } }, { \"\$or\": [ { \"type\": { \"\$in\": ['BOT_REQUEST', 'BOT_RESPONSE'] }, \"userId\": ?0 }, { \"type\": { \"\$nin\": ['BOT_REQUEST', 'BOT_RESPONSE'] } } ] } ] }")
+    fun findByIdLessThanWithBotFilter(userId: Long, cursorId: String, pageable: Pageable): List<ChatMessage>
+
 
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 채팅 기록이 사용자별로 봇 관련 메시지만 표시되도록 개선되어 개인정보 보호와 관련성(리levance)이 향상되었습니다.
  * 이전 메시지 불러오기 시 스크롤/페이지네이션 경험이 더 매끄럽게 동작합니다.
* 버그 수정
  * 드물게 다른 사용자의 봇 메시지가 채팅 목록에 섞여 보일 수 있던 문제를 해소했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->