### PR TITLE
fix: 좋아요 목록 조회 시 목록 안 보이는 오류 수정

### DIFF
--- a/src/main/kotlin/busanVibe/busan/domain/search/util/SearchUtil.kt
+++ b/src/main/kotlin/busanVibe/busan/domain/search/util/SearchUtil.kt
@@ -42,7 +42,7 @@ class SearchUtil(
                 endDate = festivalUtil.removeTime(festival.endDate),
                 isEnd = festival.endDate?.isBefore(LocalDate.now()),
                 likeCount = festivalLikeCount,
-                imgUrl = festival.festivalImages.first().imgUrl
+                imgUrl = festival.festivalImages.firstOrNull()?.imgUrl
             )
         }
 
@@ -65,7 +65,7 @@ class SearchUtil(
                 endDate = null,
                 isEnd = null,
                 likeCount = placeLikeCount,
-                imgUrl = place.placeImages.first().imgUrl.nullIfBlank()
+                imgUrl = place.placeImages.firstOrNull()?.imgUrl
             )
         }
 


### PR DESCRIPTION
좋아요 목록 조회시 이미지 목록이 비어있어 first() 메서드 호출 시 NoSuchElementException 발생하는 문제
이미지 없을 시( 배열 비어있을 시) null 반환되도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevented crashes when festivals or places have no images by safely handling missing image URLs.
  - Improved stability of search results and detail views with graceful fallbacks when images are unavailable.
  - Standardized image URL handling, reducing errors caused by empty or missing values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->