### PR TITLE
feat: AOP로 API 호출 시 로그 출력하도록 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,10 @@ dependencies {
 	// xml
 	implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.17.0")
 
+	// aop
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
+
+
 
 }
 

--- a/src/main/kotlin/busanVibe/busan/global/aop/logging/ApiRequestLogAspect.kt
+++ b/src/main/kotlin/busanVibe/busan/global/aop/logging/ApiRequestLogAspect.kt
@@ -1,0 +1,78 @@
+package busanVibe.busan.global.aop.logging
+
+import busanVibe.busan.domain.user.service.login.AuthService
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
+
+@Aspect
+@Component
+class ApiRequestLogAspect {
+
+    private val log: Logger = LoggerFactory.getLogger(ApiRequestLogAspect::class.java)
+
+    /**
+     * 전/후 처리 모두 가능
+     * CommonPointcut.controllerPointCut Pointcut 지정하여
+     * API 호출 시 호출 전후로 로그 출력하도록 하는 Aspect
+     */
+    @Around("CommonPointcut.restControllerEndpoints()")
+    fun logApiRequest(jp: ProceedingJoinPoint): Any{
+
+        // 시작시간 기록
+        val start = System.currentTimeMillis()
+
+        // 요청정보
+        val request = (RequestContextHolder.currentRequestAttributes() as ServletRequestAttributes).request
+        val uri = request.requestURI
+        val httpMethod = request.method
+        val currentUser = AuthService().getCurrentUser()
+
+        // 컨트롤러 정보
+        val methodName = jp.signature.name
+        val args = jp.args.joinToString()
+
+        // 시작 로그
+        log.info("API 호출: 유저[${currentUser.id}] - 요청 정보 [${httpMethod}: ${uri} ] - [ ${methodName}(${args}) ]")
+
+
+        // 이거 기준으로 위에는 before
+        val obj = jp.proceed()
+        // 이거 기준으로 아래는 after
+
+        // 종료시간 기록
+        val end = System.currentTimeMillis()
+
+        // 종료 로그
+        log.info("API 호출종료: 유저[${currentUser.id}] - 요청 정보 [${httpMethod}: ${uri} ] - 실행시간[${end-start}ms]")
+
+        return obj
+    }
+
+//    @Before("CommonPointcut.controllerPointcut()")
+//    fun controllerStart(jp: JoinPoint){
+//
+//        val method = jp.signature.name
+//        val args = jp.args.joinToString()
+//        log.info("API 호출: $method, args=[$args]")
+//
+//    }
+//
+//    @AfterReturning("CommonPointcut.controllerPointcut()")
+//    fun controllerFinish(jp: JoinPoint){
+//        val method = jp.signature.name
+//        log.info("API 종료(정상): $method")
+//    }
+//
+//    @AfterThrowing("CommonPointcut.controllerPointcut()")
+//    fun controllerThrowing(jp: JoinPoint){
+//        val method = jp.signature.name
+//        log.info("API 종료(비정상): $method")
+//    }
+
+}

--- a/src/main/kotlin/busanVibe/busan/global/aop/logging/CommonPointcut.kt
+++ b/src/main/kotlin/busanVibe/busan/global/aop/logging/CommonPointcut.kt
@@ -1,0 +1,13 @@
+package busanVibe.busan.global.aop.logging
+
+import org.aspectj.lang.annotation.Pointcut
+
+class CommonPointcut {
+
+    /**
+     * API 호출 시 로그 찍도록 @RestController 어노테이션에 PointCut 설정
+     */
+    @Pointcut("within(@org.springframework.web.bind.annotation.RestController *)")
+    fun restControllerEndpoints(){}
+
+}


### PR DESCRIPTION
  - AOP 의존성 추가
  - CommonPointcut 클래스 생성하여 RestController Annotation 메서드에 Pointcut 설정
  - @Around메서드 작성하여 전후로 로그(slf4j) 출력하도록 작성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added automatic logging for REST API requests, including HTTP method, path, user context, and execution time, with before/after messages for improved traceability.

- Chores
  - Introduced an AOP dependency to enable request logging across controller endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->