### PR TITLE
refactor: 명소 혼잡도 정보 redis key 통일 -> 혼잡도 일관성 보장

### DIFF
--- a/src/main/kotlin/busanVibe/busan/domain/home/service/HomeQueryService.kt
+++ b/src/main/kotlin/busanVibe/busan/domain/home/service/HomeQueryService.kt
@@ -67,7 +67,7 @@ class HomeQueryService(
 
         val places = placeRepository.findAllWithImages()
         val placesWithCongestion = places.mapNotNull { place ->
-            val congestion = placeRedisUtil.getRedisCongestion(place.id)
+            val congestion = placeRedisUtil.getTimeCongestion(place.id)
             if (congestion != null) {
                 place to congestion
             } else {
@@ -85,7 +85,7 @@ class HomeQueryService(
                 longitude = place.longitude?.toDouble(),
                 type = place.type.korean,
                 image = place.placeImages.firstOrNull()?.imgUrl.nullIfBlank(),
-                congestionLevel = congestion,
+                congestionLevel = congestion.toInt(),
                 address = place.address
             )
         }
@@ -99,12 +99,12 @@ class HomeQueryService(
 
         return places.shuffled().take(5).map { place ->
 
-            val congestion = placeRedisUtil.getRedisCongestion(place.id)
+            val congestion = placeRedisUtil.getTimeCongestion(place.id)
 
             HomeResponseDTO.RecommendPlace(
                 id = place.id,
                 name = place.name,
-                congestionLevel = congestion,
+                congestionLevel = congestion.toInt(),
                 type = place.type.korean,
                 image = place.placeImages.firstOrNull()?.imgUrl.nullIfBlank(),
                 latitude = place.latitude?.toDouble(),

--- a/src/main/kotlin/busanVibe/busan/domain/place/converter/PlaceDetailsConverter.kt
+++ b/src/main/kotlin/busanVibe/busan/domain/place/converter/PlaceDetailsConverter.kt
@@ -28,7 +28,7 @@ class PlaceDetailsConverter(
         name = place.name,
         type = place.type.capitalEnglish,
         img = placeImages.map { it.imgUrl },
-        congestionLevel = redisUtil.getRedisCongestion(place.id),
+        congestionLevel = redisUtil.getTimeCongestion(place.id).toInt(),
         likeAmount = placeLikes.size,
         address = place.address,
         isLike = isLike,

--- a/src/main/kotlin/busanVibe/busan/domain/place/service/PlaceCongestionQueryService.kt
+++ b/src/main/kotlin/busanVibe/busan/domain/place/service/PlaceCongestionQueryService.kt
@@ -68,7 +68,7 @@ class PlaceCongestionQueryService(
                 type = it.type.capitalEnglish,
                 latitude = it.latitude,
                 longitude = it.longitude,
-                congestionLevel = placeRedisUtil.getRedisCongestion(it.id)
+                congestionLevel = placeRedisUtil.getTimeCongestion(it.id).toInt()
             )
         }
 
@@ -98,7 +98,7 @@ class PlaceCongestionQueryService(
         return PlaceMapResponseDTO.PlaceDefaultInfoDto(
             id = place.id,
             name = place.name,
-            congestionLevel = placeRedisUtil.getRedisCongestion(place.id),
+            congestionLevel = placeRedisUtil.getTimeCongestion(place.id).toInt(),
             latitude = place.latitude,
             longitude = place.longitude,
             address = place.address,

--- a/src/main/kotlin/busanVibe/busan/domain/place/service/PlaceQueryService.kt
+++ b/src/main/kotlin/busanVibe/busan/domain/place/service/PlaceQueryService.kt
@@ -69,7 +69,7 @@ class PlaceQueryService(
 
         // 혼잡도 조회
         val placeRedisUtil = PlaceRedisUtil(redisTemplate)
-        val congestionMap: Map<Long, Int> = placeIdList.associateWith { placeRedisUtil.getRedisCongestion(it) }
+        val congestionMap: Map<Long, Int> = placeIdList.associateWith { placeRedisUtil.getTimeCongestion(it).toInt() }
 
 
         // DTO 변환

--- a/src/main/kotlin/busanVibe/busan/domain/place/util/PlaceRedisUtil.kt
+++ b/src/main/kotlin/busanVibe/busan/domain/place/util/PlaceRedisUtil.kt
@@ -14,19 +14,43 @@ class PlaceRedisUtil(
     private val log = LoggerFactory.getLogger("busanVibe.busan.domain.place")
 
     // 임의로 혼잡도 생성하여 반환. 레디스 키 값으로 저장함.
-    fun getRedisCongestion(placeId: Long?): Int{
+//    fun getRedisCongestion(placeId: Long?): Int{
+//
+//        val key = "place:congestion:$placeId"
+//        val randomCongestion = getRandomCongestion().toInt().toString()
+//
+//        redisTemplate.opsForValue()
+//            .set(key, randomCongestion)
+//
+//        return Integer.parseInt(randomCongestion)
+//    }
 
-        val key = "place:congestion:$placeId"
-        val randomCongestion = getRandomCongestion().toInt().toString()
+    // 지정 시간 혼잡도 조회
+    // null이면 현재시간 기준
+    fun getTimeCongestion(placeId: Long?, dateTime: LocalDateTime?): Float {
 
-        redisTemplate.opsForValue()
-            .set(key, randomCongestion)
+        val dateTime = dateTime ?: LocalDateTime.now()
 
-        return Integer.parseInt(randomCongestion)
+        val roundedHour = (dateTime.hour / 3) * 3
+        val key = "place:congestion:$placeId-${dateTime.year}-${dateTime.monthValue}-${dateTime.dayOfMonth}-$roundedHour"
+
+        val value = redisTemplate.opsForValue().get(key)
+
+        return (if (value != null) {
+            value.toFloatOrNull() ?: 0
+        } else {
+            setPlaceTimeCongestion(placeId, dateTime.withHour(roundedHour))
+            val newValue = redisTemplate.opsForValue().get(key)
+            newValue?.toFloatOrNull() ?: 0
+        }) as Float
+    }
+
+    fun getTimeCongestion(placeId: Long?):Float{
+        return getTimeCongestion(placeId, LocalDateTime.now())
     }
 
     // 시간 혼잡도 설정
-    fun setPlaceTimeCongestion(placeId: Long, dateTime: LocalDateTime) {
+    private fun setPlaceTimeCongestion(placeId: Long?, dateTime: LocalDateTime) {
         val roundedHour = (dateTime.hour / 3) * 3
         val key = "place:congestion:$placeId-${dateTime.year}-${dateTime.monthValue}-${dateTime.dayOfMonth}-$roundedHour"
         val congestion = getRandomCongestion().toString()
@@ -37,27 +61,6 @@ class PlaceRedisUtil(
         } else {
             val existing = redisTemplate.opsForValue().get(key)
             log.info("이미 존재하는 혼잡도 기록: $key, 기존 혼잡도: $existing")
-        }
-    }
-
-    // 지정 시간 혼잡도 조회
-    // null이면 현재시간 기준
-    fun getTimeCongestion(placeId: Long, dateTime: LocalDateTime?): Float {
-
-        val dateTime = dateTime ?: LocalDateTime.now()
-
-        val roundedHour = (dateTime.hour / 3) * 3
-        val key = "place:congestion:$placeId-${dateTime.year}-${dateTime.monthValue}-${dateTime.dayOfMonth}-$roundedHour"
-
-        val value = redisTemplate.opsForValue().get(key)
-
-        return if (value != null) {
-            log.info("이미 존재하는 혼잡도 기록: $key, 기존 혼잡도: $value")
-            value.toFloatOrNull() ?: 0f
-        } else {
-            setPlaceTimeCongestion(placeId, dateTime.withHour(roundedHour))
-            val newValue = redisTemplate.opsForValue().get(key)
-            newValue?.toFloatOrNull() ?: 0f
         }
     }
 

--- a/src/main/kotlin/busanVibe/busan/domain/search/util/SearchUtil.kt
+++ b/src/main/kotlin/busanVibe/busan/domain/search/util/SearchUtil.kt
@@ -59,7 +59,7 @@ class SearchUtil(
                 latitude = place.latitude?.toDouble(),
                 longitude = place.longitude?.toDouble(),
                 address = place.address,
-                congestionLevel = placeRedisUtil.getRedisCongestion(place.id),
+                congestionLevel = placeRedisUtil.getTimeCongestion(place.id).toInt(),
                 isLike = place.placeLikes.any { it.user == currentUser },
                 startDate = null,
                 endDate = null,


### PR DESCRIPTION
### 혼잡도 일관성 보장
- PlaceRedisUtil.getRedisCongestion() 메서드 사용 중지
- PlaceRedisUtil.getTimeCongestion() 메서드로 혼잡도 정보 조회 통일
- 모든 api에서 getTimeCongestion() 메서드로 일관된 혼잡도 정보 조회할 수 있도록 일부 수정
  - getTimeCongestion()메서드 호출 시, placeId만으로도 호출할 수 있도록 메서드 추가
  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Time-based congestion levels now power all place views, refreshing in 3‑hour windows for more current insights.
- Improvements
  - Consistent congestion display across Home, Place Lists, Maps, Details, Search, and Recommendations.
  - Better handling when data is unavailable, reducing empty or misleading values.
- Bug Fixes
  - Resolved inconsistencies where congestion values differed between screens.
- Performance
  - Faster, smoother loading of congestion data due to smarter caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->