### PR TITLE
fix: 명소 실시간 혼잡도 현재 시간을 중심으로 반환하도록 변경

### DIFF
--- a/src/main/kotlin/busanVibe/busan/domain/place/service/PlaceCongestionQueryService.kt
+++ b/src/main/kotlin/busanVibe/busan/domain/place/service/PlaceCongestionQueryService.kt
@@ -116,7 +116,7 @@ class PlaceCongestionQueryService(
         val roundedBase = (current.hour / 3) * 3
 
         // 최근 6개 3시간 단위 시간 생성 (기준시간 포함 총 7개)
-        val hours = (6 downTo 0).map { i -> (roundedBase - i * 3 + 24) % 24 }
+        val hours = (-3 .. 3).map { i -> (roundedBase - i * 3 + 24) % 24 }
 
         val byTimePercent: List<Float> = hours.map { hour ->
             val adjustedDateTime = current.withHour(hour)


### PR DESCRIPTION
### 명소 실시간 혼잡도 정보 표시방법 변경
[기존] 현재시간 기준으로 이전 시간 표시 -> [변경] 현재시간 기준으로 앞,뒤 시간 표시하도록 변경


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected congestion time window calculation to center around the selected hour, improving accuracy and consistency of displayed congestion trends.
  - Fixed ordering of hourly congestion data, ensuring a more intuitive progression across hours.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->