### PR TITLE
feat: 명소 혼잡도 정보 요일/시간별로 조회할 수 있도록 구현

### DIFF
--- a/src/main/kotlin/busanVibe/busan/domain/place/controller/PlaceCongestionController.kt
+++ b/src/main/kotlin/busanVibe/busan/domain/place/controller/PlaceCongestionController.kt
@@ -50,8 +50,23 @@ class PlaceCongestionController (
         return ApiResponse.onSuccess(place)
     }
 
-    @GetMapping("/place/{placeId}/real-time")
-    @Operation(summary = "명소 실시간 혼잡도 조회")
+    @GetMapping("/place/{placeId}/congestions")
+    @Operation(summary = "명소 혼잡도 조회",
+        description =
+            """
+                * congestions_by_day : 각 요일별 현재시간 기준 혼잡도
+                  - index [ 0:월, 1:화 ... 5:토, 6:일 ]
+                  
+                * congestions_by_time : 각 요일별 시간별 혼잡도 ( 0~23시 제공 )
+                  - 명소의 모든 요일의 혼잡도 제공
+                  - 총 7개의 배열, 각 배열에는 24개의 혼잡도 정보 담김
+                  
+                * standard_day와 standard_time 활용해서 현재시간 판단 가능합니다.
+                  이거도 마찬가지로 0:월 ~ 6:일
+                  
+                * 현재(실시간) 혼잡도는 real_time_congestion_level 이용하면 됩니다.
+            """
+    )
     fun placeRealTimeCongestion(
         @PathVariable("placeId") placeId: Long): ApiResponse<PlaceMapResponseDTO.PlaceCongestionDto>{
         val congestion = placeCongestionQueryService.getCongestion(placeId)

--- a/src/main/kotlin/busanVibe/busan/domain/place/dto/PlaceMapResponseDTO.kt
+++ b/src/main/kotlin/busanVibe/busan/domain/place/dto/PlaceMapResponseDTO.kt
@@ -39,9 +39,11 @@ class PlaceMapResponseDTO {
 
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
     data class PlaceCongestionDto(
+        val standardDay: Int,
         val standardTime: Int,
         val realTimeCongestionLevel: Int,
-        val byTimePercent: List<Float>
+        val congestionsByDay: List<Float>,
+        val congestionsByTime: List<List<Float>>
     )
 
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)


### PR DESCRIPTION
## 명소 혼잡도 요구사항 변경에 따른 수정

### 변경내용

[기존] 현재시간 기준 시간대별(7개) 혼잡도 제공
   ⬇️ 
[변경] 현재 기준으로 _요일별 혼잡도_ & _해당 요일의 시간대별 혼잡도_ 정보 제공

---

### 수정사항
  - 응답값 변경 - 기준 요일, 요일별 혼잡도, 시간대별 혼잡도 추가
  - 혼잡도 endpoint 변경
  - redis에 저장할 key 변경 - 요일,시간으로 표시하도록
  - 요일, 시간으로 혼잡도 구하는 메서드 추가
  - redis key 구하는 메서드 extract