### PR TITLE
큐레이션 수정 & 챗봇 이미지 적용

### DIFF
--- a/src/main/kotlin/busanVibe/busan/domain/chat/service/ChatMongoService.kt
+++ b/src/main/kotlin/busanVibe/busan/domain/chat/service/ChatMongoService.kt
@@ -30,7 +30,9 @@ class ChatMongoService(
     private val userRepository: UserRepository,
     private val openAiService: OpenAiService,
     @Value("\${image.chat-bot}")
-    private val chatBotImage: String
+    private val chatBotImage: String,
+    @Value("\${image.guest}")
+    private val guestImage: String,
 ) {
 
     val log: Logger = LoggerFactory.getLogger(ChatMongoService::class.java)
@@ -165,9 +167,17 @@ class ChatMongoService(
         // DTO 변환
         val dtoList = chatHistory.map { chat ->
             val user: User? = userMap[chat.userId ?: -1]
+            val profileImage = when (chat.type) {
+                MessageType.CHAT, MessageType.BOT_REQUEST -> {
+                    user?.profileImageUrl
+                }
+                MessageType.BOT_RESPONSE -> {
+                    chatBotImage
+                }
+            }
             ChatMessageResponseDTO.ChatInfoDto(
                 userName = user?.nickname ?: "알 수 없음",
-                userImage = user?.profileImageUrl,
+                userImage = profileImage,
                 dateTime = chat.time,
                 content = chat.message,
                 isMy = user?.id == currentUser.id,

--- a/src/main/kotlin/busanVibe/busan/domain/home/controller/HomeController.kt
+++ b/src/main/kotlin/busanVibe/busan/domain/home/controller/HomeController.kt
@@ -1,12 +1,14 @@
 package busanVibe.busan.domain.home.controller
 
 import busanVibe.busan.domain.home.dto.HomeResponseDTO
+import busanVibe.busan.domain.home.enums.CurationType
 import busanVibe.busan.domain.home.service.HomeQueryService
 import busanVibe.busan.global.apiPayload.exception.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @Tag(name = "홈화면 API")
@@ -25,15 +27,16 @@ class HomeController(
     }
 
     @GetMapping("/curation")
-    @Operation(summary = "홈화면 큐레이션 조회 API",
+    @Operation(summary = "큐레이션 조회 API",
             description =
                     """
-                        임의의 명소 1개, 축제 2개 반환
-                        ( 이미지 없는것 베재, 장소는 관광지만 조회 )                    
+                        명소 혹은 축제에 대한 큐레이션 정보를 반환합니다.
+                        type이 필요합니다. - [ PLACE, FESTIVAL ]
+                        ( 이미지 없는것은 베재, 장소는 관광지만 조회 )                    
                     """
     )
-    fun getHomeCuration(): ApiResponse<HomeResponseDTO.CurationList>{
-        val curations = homeQueryService.getCurations()
+    fun getHomeCuration(@RequestParam("type", required = true) type: CurationType): ApiResponse<HomeResponseDTO.CurationList>{
+        val curations = homeQueryService.getCurations(type)
         return ApiResponse.onSuccess(curations)
     }
 

--- a/src/main/kotlin/busanVibe/busan/domain/home/converter/CurationConverter.kt
+++ b/src/main/kotlin/busanVibe/busan/domain/home/converter/CurationConverter.kt
@@ -28,11 +28,14 @@ class CurationConverter {
         imgUrl = festival.festivalImages.first().imgUrl
     )
 
-    fun toListDto(placeList: List<Place>, festivalList: List<Festival>) : HomeResponseDTO.CurationList{
-        val placeDtoList = placeList.map { placeToDto(it) }.toList()
-        val festivalDtoList =  festivalList.map { festivalToDto(it) }.toList()
+    fun placeListToDto(placeList: List<Place>): HomeResponseDTO.CurationList {
+        val placeDtoList = placeList.map { placeToDto(it) }
+        return HomeResponseDTO.CurationList(placeDtoList)
+    }
 
-        return HomeResponseDTO.CurationList( placeDtoList + festivalDtoList )
+    fun festivalListToDto(festivalList: List<Festival>): HomeResponseDTO.CurationList {
+        val festivalDtoList = festivalList.map { festivalToDto(it) }
+        return HomeResponseDTO.CurationList(festivalDtoList)
     }
 
 

--- a/src/main/kotlin/busanVibe/busan/domain/home/enums/CurationType.kt
+++ b/src/main/kotlin/busanVibe/busan/domain/home/enums/CurationType.kt
@@ -1,0 +1,8 @@
+package busanVibe.busan.domain.home.enums
+
+enum class CurationType {
+
+    PLACE,
+    FESTIVAL
+
+}

--- a/src/main/kotlin/busanVibe/busan/domain/home/service/HomeQueryService.kt
+++ b/src/main/kotlin/busanVibe/busan/domain/home/service/HomeQueryService.kt
@@ -4,6 +4,7 @@ import busanVibe.busan.domain.festival.domain.Festival
 import busanVibe.busan.domain.festival.repository.FestivalRepository
 import busanVibe.busan.domain.home.converter.CurationConverter
 import busanVibe.busan.domain.home.dto.HomeResponseDTO
+import busanVibe.busan.domain.home.enums.CurationType
 import busanVibe.busan.domain.place.domain.Place
 import busanVibe.busan.domain.place.repository.PlaceRepository
 import busanVibe.busan.domain.place.util.PlaceRedisUtil
@@ -35,31 +36,37 @@ class HomeQueryService(
     }
 
     @Transactional(readOnly = true)
-    fun getCurations(): HomeResponseDTO.CurationList{
+    fun getCurations(type: CurationType): HomeResponseDTO.CurationList{
 
         // 자원 생성
-        val placeCount = 1
-        val festivalCount = 2
+        val resultCount = 3
 
-        // 명소 조회
-        val placeList: List<Place> = placeRepository.findPlaceImageNotNull() // 이미지 데이터가 있는 Place 목록 조회
-        val randomPlace: List<Place> = placeList
-            .takeIf { it.size >= placeCount }
-            ?.shuffled()
-            ?.take(placeCount)
-            ?: throw ExceptionHandler(ErrorStatus.PLACE_NOT_FOUND) // 그 중 랜덤한 항목 가져옴. list 비어있을 시 예외처리
+        // 조건에 따라 조회 후 DTO 반환
+        return when (type) {
+            // 명소 조회
+            CurationType.PLACE -> {
+                val placeList: List<Place> = placeRepository.findPlaceImageNotNull() // 이미지 데이터가 있는 Place 목록 조회
+                val randomPlace: List<Place> = placeList
+                    .takeIf { it.size >= resultCount }
+                    ?.shuffled()
+                    ?.take(resultCount)
+                    ?: throw ExceptionHandler(ErrorStatus.PLACE_NOT_FOUND) // 그 중 랜덤한 항목 가져옴. list 비어있을 시 예외처리
+                CurationConverter().placeListToDto(randomPlace)
+            }
 
+            // 축제 조회
+            CurationType.FESTIVAL -> {
+                val festivalList = festivalRepository.findFestivalImageNotNull() // 이미지 데이터가 있는 Festival 목록 조회
+                val randomFestival: List<Festival> = festivalList
+                    .takeIf { it.size >= resultCount }
+                    ?.shuffled()
+                    ?.take(resultCount)
+                    ?: throw ExceptionHandler(ErrorStatus.FESTIVAL_NOT_FOUND) // 그 중 랜덤한 항목 가져옴. list 비어있을 시 예외처리
+                CurationConverter().festivalListToDto(randomFestival)
+            }
 
-        // 축제 조회
-        val festivalList = festivalRepository.findFestivalImageNotNull() // 이미지 데이터가 있는 Festival 목록 조회
-        val randomFestival: List<Festival> = festivalList
-                .takeIf { it.size >= festivalCount }
-                ?.shuffled()
-                ?.take(festivalCount)
-                ?: throw ExceptionHandler(ErrorStatus.FESTIVAL_NOT_FOUND) // 그 중 랜덤한 항목 가져옴. list 비어있을 시 예외처리
+        }
 
-        // DTO 생성 및 반환
-        return CurationConverter().toListDto(randomPlace, randomFestival)
     }
 
     // 가장 붐비는 곳 조회 하여 List<DTO> 반환 - 5개


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Home curation endpoint now supports a required type filter (PLACE or FESTIVAL) to get focused recommendations.
  - Each request returns up to three curated items for the chosen type.
  - Chat history now displays appropriate profile images, showing a bot image for bot responses.

- Documentation
  - API docs updated to reflect the required type parameter and clarified response description.

- Bug Fixes
  - Clearer errors when curated items are unavailable for the requested type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->